### PR TITLE
fix(package.json): Main module discovery pointing to incorrect file type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "generate-json",
   "version": "0.1.1",
-  "main": "dist/index.cjs.js",
+  "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "jsnext:main": "dist/index.esm.js",
   "umd": "dist/index.umd.js",


### PR DESCRIPTION
generate-firestore-data was not able to find this module when doing:

var generate-json = require('generate-json')

This fixes that issue.